### PR TITLE
Enable default bevy features in examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,8 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.68"
 bevy = { version = "0.9.1", default-features = false, features = [
-  "wayland",
-  "bevy_asset",
   "bevy_render",
   "bevy_winit",
-  "filesystem_watcher",
-  "png",
 ] }
 bevy_egui = { version = "0.18.0", default-features = false }
 bevy-inspector-egui = "0.15.0"
@@ -25,6 +21,9 @@ egui = { version = "0.20.1", features = ["bytemuck"] }
 encase = "0.4.1"
 log = "0.4.17"
 rand = "0.8.5"
+
+[dev-dependencies]
+bevy = { version = "0.9.1" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Fixes #15

Enable default bevy features (including x11) in examples/tests but not for using `bevy_magic_light_2d` as a dependency.

Also made Wayland optional. ~It's still enabled by default though because winit requires either it or X11.~