### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cargo run --example krypta
 - [ ] Arbitrary number of bounces via configuration.
 - [x] Handle camera scale and rotation.
 - [ ] Support multiple layers.
-- [x] Expose settings instead of harcoding them.
+- [x] Expose settings instead of hardcoding them.
 - [x] Support resize of targets.
 - [ ] Support transparent occluders.
 - [ ] Support color transfer from occluders.


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "harcoding" to "hardcoding" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.