### PR TITLE
Use bevy's warn!() macro

### DIFF
--- a/src/gi/mod.rs
+++ b/src/gi/mod.rs
@@ -273,7 +273,7 @@ impl render_graph::Node for LightPass2DNode
                 }
             }
         } else {
-            log::warn!("Failed to get bind groups");
+            warn!("Failed to get bind groups");
         }
 
         Ok(())

--- a/src/gi/pipeline_assets.rs
+++ b/src/gi/pipeline_assets.rs
@@ -154,7 +154,7 @@ pub fn system_extract_pipeline_assets(
             probes.data[*gpu_frame_counter as usize].camera_pose =
                 camera_global_transform.translation().truncate();
         } else {
-            log::warn!("Failed to get camera");
+            warn!("Failed to get camera");
             let probes = gpu_pipeline_assets.probes.get_mut();
             probes.data[*gpu_frame_counter as usize].camera_pose = Vec2::ZERO;
         }


### PR DESCRIPTION
```
before:
WARN log: Failed to get camera

after:
WARN bevy_magic_light_2d::gi::pipeline_assets: Failed to get camera