### PR TITLE
fix: use global transform to compute lights

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "bevy_magic_light_2d"
-version = "0.6.1"
+version = "0.6.2"
 
 [features]
 default = ["egui"]
@@ -15,7 +15,7 @@ bevy = { version = "0.12", default-features = false, features = [
   "bevy_asset",
   "bevy_sprite",
   "bevy_pbr",
-] }
+]}
 bevy-inspector-egui = { version = "0.21.0", optional = true }
 log = "0.4.20"
 rand = "0.8.5"

--- a/src/gi/pipeline_assets.rs
+++ b/src/gi/pipeline_assets.rs
@@ -60,9 +60,9 @@ pub fn system_extract_pipeline_assets(
     res_light_settings:         Extract<Res<BevyMagicLight2DSettings>>,
     res_target_sizes:           Extract<Res<ComputedTargetSizes>>,
 
-    query_lights:               Extract<Query<(&Transform, &OmniLightSource2D, &InheritedVisibility, &ViewVisibility)>>,
+    query_lights:               Extract<Query<(&GlobalTransform, &OmniLightSource2D, &InheritedVisibility, &ViewVisibility)>>,
     query_occluders:            Extract<Query<(&LightOccluder2D, &Transform, &InheritedVisibility, &ViewVisibility)>>,
-    query_camera:               Extract<Query<(&Camera, &GlobalTransform), With<FloorCamera>>>,
+    query_camera:               Extract<Query<(&Camera, &Transform), With<FloorCamera>>>,
     query_masks:                Extract<Query<(&Transform, &SkylightMask2D)>>,
     query_skylight_light:       Extract<Query<&SkylightLight2D>>,
 
@@ -89,9 +89,9 @@ pub fn system_extract_pipeline_assets(
                         ..*light_source
                     },
                     Vec2::new(
-                        transform.translation.x
+                        transform.translation().x
                             + rng.gen_range(-1.0..1.0) * light_source.jitter_translation,
-                        transform.translation.y
+                        transform.translation().y
                             + rng.gen_range(-1.0..1.0) * light_source.jitter_translation,
                     ),
                 ));
@@ -107,7 +107,7 @@ pub fn system_extract_pipeline_assets(
             if hviz.get() && vviz.get() {
                 light_occluders.count += 1;
                 light_occluders.data.push(GpuLightOccluder2D::new(
-                    transform,
+                    &transform,
                     occluder.h_size,
                 ));
             }
@@ -152,7 +152,7 @@ pub fn system_extract_pipeline_assets(
 
             let probes = gpu_pipeline_assets.probes.get_mut();
             probes.data[*gpu_frame_counter as usize].camera_pose =
-                camera_global_transform.translation().truncate();
+                camera_global_transform.translation.truncate();
         } else {
             warn!("Failed to get camera");
             let probes = gpu_pipeline_assets.probes.get_mut();

--- a/src/gi/pipeline_assets.rs
+++ b/src/gi/pipeline_assets.rs
@@ -110,8 +110,7 @@ pub fn system_extract_pipeline_assets(
                     center: global_transform.translation().xy(),
                     rotation: transform.rotation.inverse().into(),
                     h_extent: occluder.h_size,
-                }
-                );
+                });
             }
         }
     }

--- a/src/gi/pipeline_assets.rs
+++ b/src/gi/pipeline_assets.rs
@@ -62,8 +62,8 @@ pub fn system_extract_pipeline_assets(
 
     query_lights:               Extract<Query<(&GlobalTransform, &OmniLightSource2D, &InheritedVisibility, &ViewVisibility)>>,
     query_occluders:            Extract<Query<(&LightOccluder2D, &GlobalTransform, &Transform, &InheritedVisibility, &ViewVisibility)>>,
-    query_camera:               Extract<Query<(&Camera, &Transform), With<FloorCamera>>>,
-    query_masks:                Extract<Query<(&Transform, &SkylightMask2D)>>,
+    query_camera:               Extract<Query<(&Camera, &GlobalTransform), With<FloorCamera>>>,
+    query_masks:                Extract<Query<(&GlobalTransform, &SkylightMask2D)>>,
     query_skylight_light:       Extract<Query<&SkylightLight2D>>,
 
     mut gpu_target_sizes:       ResMut<ComputedTargetSizes>,
@@ -123,7 +123,7 @@ pub fn system_extract_pipeline_assets(
         for (transform, mask) in query_masks.iter() {
             skylight_masks.count += 1;
             skylight_masks.data.push(GpuSkylightMaskData::new(
-                transform.translation.truncate(),
+                transform.translation().truncate(),
                 mask.h_size,
             ));
         }
@@ -154,7 +154,7 @@ pub fn system_extract_pipeline_assets(
 
             let probes = gpu_pipeline_assets.probes.get_mut();
             probes.data[*gpu_frame_counter as usize].camera_pose =
-                camera_global_transform.translation.truncate();
+                camera_global_transform.translation().truncate();
         } else {
             warn!("Failed to get camera");
             let probes = gpu_pipeline_assets.probes.get_mut();

--- a/src/gi/types_gpu.rs
+++ b/src/gi/types_gpu.rs
@@ -43,21 +43,6 @@ pub struct GpuLightOccluder2D {
     pub h_extent: Vec2,
 }
 
-// impl GpuLightOccluder2D
-// {
-//     pub fn new(transform: &GlobalTransform, h_extent: Vec2) -> Self
-//     {
-//         let center = transform.translation().xy();
-//         let rotation = transform.rotation.inverse().into();
-//         // let h_extent = h_extent * transform.scale.xy();
-//         Self {
-//             center,
-//             rotation,
-//             h_extent,
-//         }
-//     }
-// }
-
 #[rustfmt::skip]
 #[derive(Default, Clone, ShaderType)]
 pub struct GpuLightOccluderBuffer {

--- a/src/gi/types_gpu.rs
+++ b/src/gi/types_gpu.rs
@@ -1,5 +1,4 @@
-use bevy::math::Vec3Swizzles;
-use bevy::prelude::{Mat4, Transform, Vec2, Vec3, Vec4};
+use bevy::prelude::{Mat4, Vec2, Vec3, Vec4};
 use bevy::render::render_resource::ShaderType;
 
 use crate::gi::constants::GI_SCREEN_PROBE_SIZE;
@@ -44,20 +43,20 @@ pub struct GpuLightOccluder2D {
     pub h_extent: Vec2,
 }
 
-impl GpuLightOccluder2D
-{
-    pub fn new(transform: &Transform, h_extent: Vec2) -> Self
-    {
-        let center = transform.translation.xy();
-        let rotation = transform.rotation.inverse().into();
-        // let h_extent = h_extent * transform.scale.xy();
-        Self {
-            center,
-            rotation,
-            h_extent,
-        }
-    }
-}
+// impl GpuLightOccluder2D
+// {
+//     pub fn new(transform: &GlobalTransform, h_extent: Vec2) -> Self
+//     {
+//         let center = transform.translation().xy();
+//         let rotation = transform.rotation.inverse().into();
+//         // let h_extent = h_extent * transform.scale.xy();
+//         Self {
+//             center,
+//             rotation,
+//             h_extent,
+//         }
+//     }
+// }
 
 #[rustfmt::skip]
 #[derive(Default, Clone, ShaderType)]


### PR DESCRIPTION
This allows you to add a light source (or multiple) as a child of an entity and position it relatively using `SpacialBundle` or similar. This is useful for creating entities that are made up of multiple parts, such as a car with headlights, a character with an aura and a torch, etc, without having to manually position the light sources.

I tested this in my own project and with the krypta example.
