### PR TITLE
fix: move post processing material along with camera

### DIFF
--- a/src/gi/compositing.rs
+++ b/src/gi/compositing.rs
@@ -210,20 +210,6 @@ pub fn setup_post_processing_camera(
     let layer = RenderLayers::layer((RenderLayers::TOTAL_LAYERS - 1) as u8);
 
     commands.spawn((
-        PostProcessingQuad,
-        MaterialMesh2dBundle {
-            mesh: POST_PROCESSING_QUAD.clone().into(),
-            material: POST_PROCESSING_MATERIAL.clone(),
-            transform: Transform {
-                translation: Vec3::new(0.0, 0.0, 1.5),
-                ..default()
-            },
-            ..default()
-        },
-        layer,
-    ));
-
-    commands.spawn((
         Name::new("post_processing_camera"),
         Camera2dBundle {
             camera: Camera {
@@ -238,5 +224,17 @@ pub fn setup_post_processing_camera(
             ..default()
         },
         layer
+    ))
+    .insert((
+        PostProcessingQuad,
+        MaterialMesh2dBundle {
+            mesh: POST_PROCESSING_QUAD.clone().into(),
+            material: POST_PROCESSING_MATERIAL.clone(),
+            transform: Transform {
+                translation: Vec3::new(0.0, 0.0, 1.5),
+                ..default()
+            },
+            ..default()
+        },
     ));
 }


### PR DESCRIPTION
If we don't move the Quad material along with the camera we'll get a cropped up viewport as the player moves the camera around. Adding those to the same entity (and as such making them share a transform), solves the issue.

Fixes #51
